### PR TITLE
Fixing virt version check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,3 @@ cobbler4j/target
 
 # Testrun output
 test.log
-
-.dev

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ cobbler4j/target
 
 # Testrun output
 test.log
+
+.dev

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ release: clean qa authors sdist doc
 	@cp debian/rules release/debian.rules
 
 nosetests:
-	PYTHONPATH=./koan/ nosetests -v -w tests/koan/ 2>&1 | tee test.log
+	PYTHONPATH=./koan/ nosetests -v -w tests/cli/ 2>&1 | tee test.log
 
 build:
 	python setup.py build -f

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ release: clean qa authors sdist doc
 	@cp debian/rules release/debian.rules
 
 nosetests:
-	PYTHONPATH=./koan/ nosetests -v -w tests/cli/ 2>&1 | tee test.log
+	PYTHONPATH=./koan/ nosetests -v -w tests/koan/ 2>&1 | tee test.log
 
 build:
 	python setup.py build -f
@@ -90,5 +90,5 @@ rpms: release
 
 
 .PHONY: tags
-tags: 
+tags:
 	find . \( -name build -o -name .git \) -prune -o -type f -name '*.py' -print | xargs etags -o TAGS --

--- a/koan/app.py
+++ b/koan/app.py
@@ -735,7 +735,8 @@ class Koan:
                 # is libvirt new enough?
                 rc, version_str = utils.subprocess_get_response(
                     shlex.split('/usr/bin/virt-install --version'), True)
-                if rc != 0 or utils.check_version_greater_or_equal(version_str.strip(), "0.2.0"):
+                version_str = version_str.strip()
+                if len(version_str) == 0 and not utils.check_version_greater_or_equal(version_str, "0.2.0"):
                     raise InfoException(
                         "need python-virtinst >= 0.2 or virt-install package to do installs for qemu/kvm (depending on your OS)")
 

--- a/koan/app.py
+++ b/koan/app.py
@@ -735,7 +735,7 @@ class Koan:
                 # is libvirt new enough?
                 rc, version_str = utils.subprocess_get_response(
                     shlex.split('/usr/bin/virt-install --version'), True)
-                if rc != 0 or _check_version_greater_or_equal(version_str.strip(), "0.2.0"):
+                if rc != 0 or utils.check_version_greater_or_equal(version_str.strip(), "0.2.0"):
                     raise InfoException(
                         "need python-virtinst >= 0.2 or virt-install package to do installs for qemu/kvm (depending on your OS)")
 
@@ -2070,17 +2070,6 @@ class Koan:
             return uuid
         return self.uuidToString(self.randomUUID())
 
-    def _check_version_greater_or_equal(version1, version2):
-        ass = version1.split(".")
-        bss = version2.split(".")
-        if len(ass) != len(bss):
-           raise Exception("expected version format differs")
-        for i, a in enumerate(ass):
-           a = int(a)
-           b = int(bss[i])
-           if a < b:
-               return False
-        return True
 
 if __name__ == "__main__":
     main()

--- a/koan/app.py
+++ b/koan/app.py
@@ -735,7 +735,7 @@ class Koan:
                 # is libvirt new enough?
                 rc, version_str = utils.subprocess_get_response(
                     shlex.split('/usr/bin/virt-install --version'), True)
-                if rc != 0 or re.match('^0\.[01]\..*', version_str):
+                if rc != 0 or _check_version_greater_or_equal(version_str.strip(), "0.2.0"):
                     raise InfoException(
                         "need python-virtinst >= 0.2 or virt-install package to do installs for qemu/kvm (depending on your OS)")
 
@@ -2069,6 +2069,18 @@ class Koan:
         if uuid:
             return uuid
         return self.uuidToString(self.randomUUID())
+
+    def _check_version_greater_or_equal(version1, version2):
+        ass = version1.split(".")
+        bss = version2.split(".")
+        if len(ass) != len(bss):
+           raise Exception("expected version format differs")
+        for i, a in enumerate(ass):
+           a = int(a)
+           b = int(bss[i])
+           if a < b:
+               return False
+        return True
 
 if __name__ == "__main__":
     main()

--- a/koan/utils.py
+++ b/koan/utils.py
@@ -604,3 +604,15 @@ def random_mac():
 
 def generate_timestamp():
     return str(int(time.time()))
+
+def check_version_greater_or_equal(version1, version2):
+    ass = version1.split(".")
+    bss = version2.split(".")
+    if len(ass) != len(bss):
+       raise Exception("expected version format differs")
+    for i, a in enumerate(ass):
+       a = int(a)
+       b = int(bss[i])
+       if a < b:
+           return False
+    return True

--- a/tests/koan/virtinstall.py
+++ b/tests/koan/virtinstall.py
@@ -207,7 +207,7 @@ class KoanVirtInstallTest(unittest.TestCase):
             ("2.2.19", "2.2.2", True),
             ("1.1.0", "2.2.2", False),
             ("1.2.1", "2.2.2", False),
-            ("2.2.2", "2.2.2", False),
+            ("2.2.2", "2.2.2", True),
         ]
         for t in tss:
             self.assertTrue(koan.app._check_version_greater_or_equal(t[0],

--- a/tests/koan/virtinstall.py
+++ b/tests/koan/virtinstall.py
@@ -199,6 +199,20 @@ class KoanVirtInstallTest(unittest.TestCase):
              "--network bridge=br2 --wait 0 --noautoconsole")
         )
 
+    def testVirtVersionCheckTest(self):
+        tss = [
+            ("19.19.19", "2.2.2", True),
+            ("1.19.19", "2.2.2", False),
+            ("2.19.19", "2.2.2", True),
+            ("2.2.19", "2.2.2", True),
+            ("1.1.0", "2.2.2", False),
+            ("1.2.1", "2.2.2", False),
+            ("2.2.2", "2.2.2", False),
+        ]
+        for t in tss:
+            self.assertTrue(koan.app._check_version_greater_or_equal(t[0],
+                            t[1]) == t[2])
+
     @patch('koan.virtinstall.utils.subprocess_call')
     @patch('koan.virtinstall.utils.os.path', new_callable=OsPathMock)
     def test_create_qcow_file(self, mock_path, mock_subprocess):

--- a/tests/koan/virtinstall.py
+++ b/tests/koan/virtinstall.py
@@ -1,5 +1,6 @@
 import unittest
 import koan
+import koan.utils
 
 from koan.virtinstall import build_commandline
 from koan.virtinstall import create_image_file
@@ -210,7 +211,7 @@ class KoanVirtInstallTest(unittest.TestCase):
             ("2.2.2", "2.2.2", True),
         ]
         for t in tss:
-            self.assertTrue(koan.app._check_version_greater_or_equal(t[0],
+            self.assertTrue(utils.check_version_greater_or_equal(t[0],
                             t[1]) == t[2])
 
     @patch('koan.virtinstall.utils.subprocess_call')


### PR DESCRIPTION
This pull-request will fix issue #5, double digits in Virt's version: "0.10.0". The regular expression is replaced by a more thorough check, which splits the version on separator token, and checks all numbers individually. 

PS. I've added a test for the function as well, however `make notetests` returns that 0 tests have ran.