### PR TITLE
Split only once for creating key-value pairs

### DIFF
--- a/koan/utils.py
+++ b/koan/utils.py
@@ -188,7 +188,7 @@ def input_string_or_dict(options, delim=None, allow_multiples=True):
         new_dict = {}
         tokens = string.split(options, delim)
         for t in tokens:
-            tokens2 = string.split(t, "=")
+            tokens2 = string.split(t, "=", 1)
             if len(tokens2) == 1:
                 # this is a singleton option, no value
                 key = tokens2[0]


### PR DESCRIPTION
Changing behaviour of **input_string_or_dict** method to be same as it's cobbler [equivalent](https://github.com/cobbler/cobbler/blob/master/cobbler/utils.py#L501).

Also fixing possible problems with parsing of kernel parameters with multiple equal signs.