### PR TITLE
Do version comparison properly

### DIFF
--- a/koan/utils.py
+++ b/koan/utils.py
@@ -613,6 +613,8 @@ def check_version_greater_or_equal(version1, version2):
     for i, a in enumerate(ass):
        a = int(a)
        b = int(bss[i])
+       if a > b:
+           return True
        if a < b:
            return False
     return True


### PR DESCRIPTION
We should compare subsequent octets only if the previous ones are equal.
Currently there is only a "<" check so comparing 1.1.0 with 0.2.0 returns False.