### PR TITLE
report errors of virt-install by throwing them in an exception

### DIFF
--- a/koan/imagecreate.py
+++ b/koan/imagecreate.py
@@ -29,4 +29,6 @@ from . import virtinstall
 
 def start_install(*args, **kwargs):
     cmd = virtinstall.build_commandline("import", *args, **kwargs)
-    utils.subprocess_call(cmd)
+    rc, result, result_stderr = utils.subprocess_get_response(cmd, ignore_rc=True, get_stderr=True)
+    if rc != 0:
+        raise utils.InfoException, "command failed (%s): %s %s" % (rc, result, result_stderr)

--- a/koan/qcreate.py
+++ b/koan/qcreate.py
@@ -30,4 +30,6 @@ import virtinstall
 def start_install(*args, **kwargs):
     virtinstall.create_image_file(*args, **kwargs)
     cmd = virtinstall.build_commandline("qemu:///system", *args, **kwargs)
-    utils.subprocess_call(cmd)
+    rc, result, result_stderr = utils.subprocess_get_response(cmd, ignore_rc=True, get_stderr=True)
+    if rc != 0:
+        raise utils.InfoException, "command failed (%s): %s %s" % (rc, result, result_stderr)

--- a/koan/xencreate.py
+++ b/koan/xencreate.py
@@ -32,4 +32,6 @@ from . import virtinstall
 
 def start_install(*args, **kwargs):
     cmd = virtinstall.build_commandline("xen:///", *args, **kwargs)
-    utils.subprocess_call(cmd)
+    rc, result, result_stderr = utils.subprocess_get_response(cmd, ignore_rc=True, get_stderr=True)
+    if rc != 0:
+        raise utils.InfoException, "command failed (%s): %s %s" % (rc, result, result_stderr)


### PR DESCRIPTION
In case of used via spacewalk, it only see the exception.
Adding the errors to the exception will guide the user into the right direction what was the 
reason of the error.