### PR TITLE
Making code compatible with Python 3

### DIFF
--- a/koan.spec
+++ b/koan.spec
@@ -12,8 +12,25 @@
 # https://build.opensuse.org/project/subprojects/home:libertas-ict
 #
 
-%{!?python_sitelib: %global python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
-%{!?python_sitearch: %global python_sitearch %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(1))")}
+%if 0%{?fedora}
+%global use_python3 1
+%global use_python2 0
+%global pythonbin %{__python3}
+%global python_sitelib %{python3_sitelib}
+%else
+%global use_python3 0
+%global use_python2 1
+%if 0%{?__python2:1}
+%global pythonbin %{__python2}
+%global python_sitelib %{python2_sitelib}
+%else
+%global pythonbin %{__python}
+%global python_sitelib %{python_sitelib}
+%endif
+%endif
+
+%{!?python_sitelib: %global python_sitelib %(%{pythonbin} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
+%{!?python_sitearch: %global python_sitearch %(%{pythonbin} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(1))")}
 
 %global debug_package %{nil}
 %define _binaries_in_noarch_packages_terminate_build 1
@@ -40,13 +57,19 @@ Url: http://github.com/cobbler/koan
 BuildArchitectures: noarch
 %endif
 
+%if %{use_python3}
+BuildRequires: python3
+Requires: python3
+Requires: python3-netifaces
+%else
 BuildRequires: python >= 2.3
-
 Requires: python >= 2.3
 Requires: python-ethtool
 
 %if 0%{?suse_version} == 1010
 BuildRequires: python-devel
+%endif
+
 %endif
 
 
@@ -61,11 +84,11 @@ bla
 %setup -n %{name}-%{unmangled_version}
 
 %build
-%{__python} setup.py build
+%{pythonbin} setup.py build
 
 %install
 test "x$RPM_BUILD_ROOT" != "x" && rm -rf $RPM_BUILD_ROOT
-%{__python} setup.py install -O1 --prefix=%{_prefix} --root=%{buildroot} --record=INSTALLED_FILES
+%{pythonbin} setup.py install -O1 --prefix=%{_prefix} --root=%{buildroot} --record=INSTALLED_FILES
 
 %clean
 rm -rf $RPM_BUILD_ROOT

--- a/koan.spec
+++ b/koan.spec
@@ -61,10 +61,12 @@ BuildArchitectures: noarch
 BuildRequires: python3
 Requires: python3
 Requires: python3-netifaces
+Requires: python3-simplejson
 %else
 BuildRequires: python >= 2.3
 Requires: python >= 2.3
 Requires: python-ethtool
+Requires: python-simplejson
 
 %if 0%{?suse_version} == 1010
 BuildRequires: python-devel

--- a/koan/app.py
+++ b/koan/app.py
@@ -1097,7 +1097,7 @@ class Koan:
     def get_boot_loader_info(self):
         cmd = ["/sbin/grubby", "--bootloader-probe"]
         probe_process = subprocess.Popen(cmd, stdout=subprocess.PIPE)
-        which_loader = probe_process.communicate()[0]
+        which_loader = probe_process.communicate()[0].decode()
         return probe_process.returncode, which_loader
 
     def replace(self):
@@ -1153,7 +1153,7 @@ class Koan:
                 "/bin/uname -m",
                 stdout=subprocess.PIPE,
                 shell=True)
-            arch = arch_cmd.communicate()[0]
+            arch = arch_cmd.communicate()[0].decode()
 
             # Validate kernel argument length (limit depends on architecture --
             # see asm-*/setup.h).  For example:

--- a/koan/app.py
+++ b/koan/app.py
@@ -39,7 +39,7 @@ import re
 import sys
 import string
 import socket
-from cexceptions import InfoException
+from .cexceptions import InfoException
 from . import utils
 from . import configurator
 

--- a/koan/app.py
+++ b/koan/app.py
@@ -37,7 +37,6 @@ import shutil
 import errno
 import re
 import sys
-import string
 import socket
 from .cexceptions import InfoException
 from . import utils
@@ -1191,7 +1190,7 @@ class Koan:
                     cmd.append("--copy-default")
 
                 boot_probe_ret_code, probe_output = self.get_boot_loader_info()
-                if boot_probe_ret_code == 0 and string.find(probe_output, "lilo") >= 0:
+                if boot_probe_ret_code == 0 and probe_output.find("lilo") >= 0:
                     cmd.append("--lilo")
 
                 if self.add_reinstall_entry:
@@ -1235,7 +1234,7 @@ class Koan:
                 else:
                     # if grubby --bootloader-probe returns lilo,
                     #    apply lilo changes
-                    if boot_probe_ret_code == 0 and string.find(probe_output, "lilo") != -1:
+                    if boot_probe_ret_code == 0 and probe_output.find("lilo") != -1:
                         print("- applying lilo changes")
                         cmd = ["/sbin/lilo"]
                         utils.subprocess_call(cmd)

--- a/koan/app.py
+++ b/koan/app.py
@@ -1540,10 +1540,10 @@ class Koan:
             hash2 = utils.input_string_or_dict(self.kopts_override)
             hashv.update(hash2)
         options = utils.dict_to_string(hashv)
-        options = string.replace(options, "lang ", "lang= ")
+        options = options.replace("lang ", "lang= ")
         # if using ksdevice=bootif that only works for PXE so replace
         # it with something that will work
-        options = string.replace(options, "ksdevice=bootif", "ksdevice=link")
+        options = options.replace("ksdevice=bootif", "ksdevice=link")
         return options
 
     def virt_net_install(self, profile_data):

--- a/koan/app.py
+++ b/koan/app.py
@@ -571,7 +571,7 @@ class Koan:
         systems = self.get_data("systems")
         for system in systems:
             obj_name = system["name"]
-            for (obj_iname, obj_interface) in system['interfaces'].iteritems():
+            for (obj_iname, obj_interface) in system['interfaces'].items():
                 mac = obj_interface["mac_address"].upper()
                 ip = obj_interface["ip_address"].upper()
                 for my_mac in mac_criteria:

--- a/koan/app.py
+++ b/koan/app.py
@@ -379,7 +379,7 @@ def main():
         except:
             print(xa)
             print(xb)
-            print(string.join(traceback.format_list(traceback.extract_tb(tb))))
+            print("".join(traceback.format_list(traceback.extract_tb(tb))))
         return 1
 
     return 0

--- a/koan/imagecreate.py
+++ b/koan/imagecreate.py
@@ -31,4 +31,4 @@ def start_install(*args, **kwargs):
     cmd = virtinstall.build_commandline("import", *args, **kwargs)
     rc, result, result_stderr = utils.subprocess_get_response(cmd, ignore_rc=True, get_stderr=True)
     if rc != 0:
-        raise utils.InfoException, "command failed (%s): %s %s" % (rc, result, result_stderr)
+        raise utils.InfoException("command failed (%s): %s %s" % (rc, result, result_stderr))

--- a/koan/openvzcreate.py
+++ b/koan/openvzcreate.py
@@ -22,7 +22,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 from __future__ import print_function
 
 import os
-from cexceptions import OVZCreateException
+from .cexceptions import OVZCreateException
 
 
 def start_install(*args, **kwargs):

--- a/koan/qcreate.py
+++ b/koan/qcreate.py
@@ -32,4 +32,4 @@ def start_install(*args, **kwargs):
     cmd = virtinstall.build_commandline("qemu:///system", *args, **kwargs)
     rc, result, result_stderr = utils.subprocess_get_response(cmd, ignore_rc=True, get_stderr=True)
     if rc != 0:
-        raise utils.InfoException, "command failed (%s): %s %s" % (rc, result, result_stderr)
+        raise utils.InfoException("command failed (%s): %s %s" % (rc, result, result_stderr))

--- a/koan/register.py
+++ b/koan/register.py
@@ -30,7 +30,6 @@ import sys
 import socket
 from . import utils
 from .cexceptions import InfoException
-import string
 
 # usage: cobbler-register [--server=server] [--fqdn=hostname] --profile=foo
 
@@ -98,7 +97,7 @@ def main():
         except:
             print(xa)
             print(xb)
-            print(string.join(traceback.format_list(traceback.extract_tb(tb))))
+            print("".join(traceback.format_list(traceback.extract_tb(tb))))
         return 1
 
     return 0

--- a/koan/register.py
+++ b/koan/register.py
@@ -29,7 +29,7 @@ import time
 import sys
 import socket
 from . import utils
-from cexceptions import InfoException
+from .cexceptions import InfoException
 import string
 
 # usage: cobbler-register [--server=server] [--fqdn=hostname] --profile=foo

--- a/koan/utils.py
+++ b/koan/utils.py
@@ -41,7 +41,6 @@ except ImportError:  # python 3
 import subprocess
 import shutil
 import sys
-import string
 import time
 from .cexceptions import KX, InfoException
 
@@ -192,9 +191,9 @@ def input_string_or_dict(options, delim=None, allow_multiples=True):
         raise InfoException("No idea what to do with list: %s" % options)
     elif isinstance(options, type("")):
         new_dict = {}
-        tokens = string.split(options, delim)
+        tokens = options.split(delim)
         for t in tokens:
-            tokens2 = string.split(t, "=", 1)
+            tokens2 = t.split("=", 1)
             if len(tokens2) == 1:
                 # this is a singleton option, no value
                 key = tokens2[0]

--- a/koan/utils.py
+++ b/koan/utils.py
@@ -37,7 +37,7 @@ import string
 import urlgrabber
 import ethtool
 import time
-from cexceptions import KX, InfoException
+from .cexceptions import KX, InfoException
 
 VIRT_STATE_NAME_MAP = {
     0: "running",

--- a/koan/utils.py
+++ b/koan/utils.py
@@ -28,7 +28,10 @@ import random
 import re
 import traceback
 import tempfile
-import urllib2
+try:  # python 2
+    import urllib2
+except ImportError:  # python 3
+    import urllib.request as urllib2
 import subprocess
 import shutil
 import sys

--- a/koan/utils.py
+++ b/koan/utils.py
@@ -142,7 +142,7 @@ def urlgrab(url, saveto):
     see comments for urlread as to why it's this way.
     """
     data = urlread(url)
-    fd = open(saveto, "w+")
+    fd = open(saveto, "w+b")
     fd.write(data)
     fd.close()
 

--- a/koan/utils.py
+++ b/koan/utils.py
@@ -605,16 +605,17 @@ def random_mac():
 def generate_timestamp():
     return str(int(time.time()))
 
+
 def check_version_greater_or_equal(version1, version2):
     ass = version1.split(".")
     bss = version2.split(".")
     if len(ass) != len(bss):
-       raise Exception("expected version format differs")
+        raise Exception("expected version format differs")
     for i, a in enumerate(ass):
-       a = int(a)
-       b = int(bss[i])
-       if a > b:
-           return True
-       if a < b:
-           return False
+        a = int(a)
+        b = int(bss[i])
+        if a > b:
+            return True
+        if a < b:
+            return False
     return True

--- a/koan/utils.py
+++ b/koan/utils.py
@@ -30,12 +30,13 @@ import traceback
 import tempfile
 try:  # python 2
     import urllib2
+    import xmlrpclib
 except ImportError:  # python 3
     import urllib.request as urllib2
+    import xmlrpc.client as xmlrpclib
 import subprocess
 import shutil
 import sys
-import xmlrpclib
 import string
 import urlgrabber
 import ethtool

--- a/koan/utils.py
+++ b/koan/utils.py
@@ -259,7 +259,7 @@ def nfsmount(input_path):
     # FIXME: move this function to util.py so other modules can use it
     # we have to mount it first
     filename = input_path.split("/")[-1]
-    dirpath = string.join(input_path.split("/")[:-1], "/")
+    dirpath = "/".join(input_path.split("/")[:-1])
     tempdir = tempfile.mkdtemp(suffix='.mnt', prefix='koan_', dir='/tmp')
     mount_cmd = [
         "/bin/mount", "-t", "nfs", "-o", "ro", dirpath, tempdir
@@ -601,7 +601,7 @@ def create_qemu_image_file(path, size, driver_type):
     except:
         traceback.print_exc()
         raise InfoException(
-            "Image file create failed: %s" % string.join(cmd, " ")
+            "Image file create failed: %s" % " ".join(cmd)
         )
 
 

--- a/koan/utils.py
+++ b/koan/utils.py
@@ -38,7 +38,6 @@ import subprocess
 import shutil
 import sys
 import string
-import urlgrabber
 import ethtool
 import time
 from .cexceptions import KX, InfoException
@@ -538,7 +537,7 @@ def make_floppy(autoinst):
     # download the autoinst file onto the mounted floppy
     print("- downloading %s" % autoinst)
     save_file = os.path.join(mount_path, "unattended.txt")
-    urlgrabber.urlgrab(autoinst, filename=save_file)
+    urlgrab(autoinst, save_file)
 
     # umount
     cmd = "umount %s" % mount_path

--- a/koan/utils.py
+++ b/koan/utils.py
@@ -395,7 +395,7 @@ def uniqify(lst, purge=None):
             if x != purge:
                 temp2[x] = 1
         temp = temp2
-    return temp.keys()
+    return list(temp.keys())
 
 
 def get_network_info():

--- a/koan/virtinstall.py
+++ b/koan/virtinstall.py
@@ -32,7 +32,7 @@ import os
 import re
 import shlex
 from . import utils
-from cexceptions import InfoException
+from .cexceptions import InfoException
 
 # The virtinst module will no longer be availabe to import in some
 # distros. We need to get all the info we need from the virt-install

--- a/koan/vmwcreate.py
+++ b/koan/vmwcreate.py
@@ -23,7 +23,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 from __future__ import print_function
 
 import os
-from cexceptions import VirtCreateException, InfoException
+from .cexceptions import VirtCreateException, InfoException
 
 IMAGE_DIR = "/var/lib/vmware/images"
 VMX_DIR = "/var/lib/vmware/vmx"

--- a/koan/xencreate.py
+++ b/koan/xencreate.py
@@ -34,4 +34,4 @@ def start_install(*args, **kwargs):
     cmd = virtinstall.build_commandline("xen:///", *args, **kwargs)
     rc, result, result_stderr = utils.subprocess_get_response(cmd, ignore_rc=True, get_stderr=True)
     if rc != 0:
-        raise utils.InfoException, "command failed (%s): %s %s" % (rc, result, result_stderr)
+        raise utils.InfoException("command failed (%s): %s %s" % (rc, result, result_stderr))

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     packages=['koan'],
     license='GPLv2',
     scripts=['bin/koan', 'bin/cobbler-register'],
-    #data_files=[('/etc/zenossctl', ['config/zenossctl.json'])],
+    # data_files=[('/etc/zenossctl', ['config/zenossctl.json'])],
 )
 
 # EOF

--- a/tests/aux/create_kvm_guest.py
+++ b/tests/aux/create_kvm_guest.py
@@ -16,7 +16,10 @@ import shlex
 import shutil
 import socket
 import subprocess
-import urllib2
+try:  # python 2
+    import urllib2
+except ImportError:  # python 3
+    import urllib.request as urllib2
 
 DEBUG = True
 # default number of CPUs


### PR DESCRIPTION
Attempt to make Koan code compatible with Python 3. Not everything is fixed, probably yet. It's just minimal set of changes needed to successfully initiate kickstart on Spacewalk Fedora 24 clients.

I changed specfile to build for Python 3 on all Fedora and kept same package name for now but it's open to change.
