### PR TITLE
Switch to distro module

### DIFF
--- a/koan/configurator.py
+++ b/koan/configurator.py
@@ -56,7 +56,7 @@ class KoanConfigure:
         """Constructor. Requires json config object."""
         self.config = json.JSONDecoder().decode(config)
         self.stats = {}
-        self.dist = utils.check_dist()
+        (self.dist, _) = utils.os_release()
 
     def configure_repos(self):
         # Enables the possibility to use different types of repos

--- a/koan/utils.py
+++ b/koan/utils.py
@@ -330,7 +330,7 @@ def check_dist():
     """
     Determines what distro we're running under (with the distro module).
     """
-    distroname = distro.id()
+    distroname = distro.like()
     if distroname is "debian":
         return distroname
     elif distroname is "suse" or distroname is "sles" or "opensuse" in distroname:
@@ -349,14 +349,13 @@ def os_release():
         str is the name
         int is the version number
     """
-    distroname, version, codename = distro.linux_distribution(full_distribution_name=True)
+    distroname = distro.like()
+    version = distro.version()
 
-    allowed_distros = ["rhel", "centos", "fedora", "debian", "ubuntu"]
+    allowed_distros = ["rhel", "centos", "fedora", "debian", "ubuntu", "suse"]
 
     if distroname in allowed_distros:
         return distroname, float(version)
-    elif distroname is "sles" or "suse" or "opensuse" in distroname:
-        return "suse", float(version)
     else:
         return "unkown", 0.0
 

--- a/koan/utils.py
+++ b/koan/utils.py
@@ -325,22 +325,6 @@ def get_vm_state(conn, vmid):
     return VIRT_STATE_NAME_MAP.get(state, "unknown")
 
 
-def check_dist():
-    """
-    Determines what distro we're running under (with the distro module).
-    """
-    # FIXME: This mimics the old logic but is certanly wrong
-
-    if distro.id() is "debian":
-        return "debian"
-
-    if distro.like() is "suse":
-        return "suse"
-
-    # valid for Fedora and all Red Hat / Fedora derivatives
-    return "redhat"
-
-
 def os_release():
     """
     This code detects your os with the distro module and return the name and version. If it is not detected correctly it

--- a/koan/utils.py
+++ b/koan/utils.py
@@ -29,6 +29,8 @@ import re
 import tempfile
 import traceback
 
+import distro
+
 try:  # python 2
     import urllib2
     import xmlrpclib
@@ -257,7 +259,6 @@ def dict_to_string(hash):
 def nfsmount(input_path):
     # input:  [user@]server:/foo/bar/x.img as string
     # output:  (dirname where mounted, last part of filename) as 2-element tuple
-    # FIXME: move this function to util.py so other modules can use it
     # we have to mount it first
     filename = input_path.split("/")[-1]
     dirpath = "/".join(input_path.split("/")[:-1])
@@ -327,12 +328,12 @@ def get_vm_state(conn, vmid):
 
 def check_dist():
     """
-    Determines what distro we're running under.
+    Determines what distro we're running under (with the distro module).
     """
-    if os.path.exists("/etc/debian_version"):
-        import lsb_release
-        return lsb_release.get_distro_information()['ID'].lower()
-    elif os.path.exists("/etc/SuSE-release"):
+    distroname = distro.id()
+    if distroname is "debian":
+        return distroname
+    elif distroname is "suse" or distroname is "sles" or "opensuse" in distroname:
         return "suse"
     else:
         # valid for Fedora and all Red Hat / Fedora derivatives
@@ -341,49 +342,23 @@ def check_dist():
 
 def os_release():
     """
-    This code is borrowed from Cobbler and really shouldn't be repeated.
+    This code detects your os with the distro module and return the name and version. If it is not detected correctly it
+    returns "unkown" (str) and "0" (float).
+    @:returns tuple (str, float)
+        WHERE
+        str is the name
+        int is the version number
     """
-    if check_dist() == "redhat":
-        fh = open("/etc/redhat-release")
-        data = fh.read().lower()
-        if data.find("fedora") != -1:
-            make = "fedora"
-        elif data.find("centos") != -1:
-            make = "centos"
-        else:
-            make = "redhat"
-        release_index = data.find("release")
-        rest = data[release_index + 7:-1]
-        tokens = rest.split(" ")
-        for t in tokens:
-            try:
-                match = re.match('^\d+(?:\.\d+)?', t)
-                if match:
-                    return (make, float(match.group(0)))
-            except ValueError:
-                pass
-        raise KX("failed to detect local OS version from /etc/redhat-release")
+    distroname, version, codename = distro.linux_distribution(full_distribution_name=True)
 
-    elif check_dist() == "debian":
-        import lsb_release
-        release = lsb_release.get_distro_information()['RELEASE']
-        return ("debian", release)
-    elif check_dist() == "ubuntu":
-        version = subprocess.check_output(
-            ("lsb_release", "--release", "--short")).rstrip()
-        make = "ubuntu"
-        return (make, float(version))
-    elif check_dist() in ("suse", "opensuse"):
-        fd = open("/etc/SuSE-release")
-        for line in fd.read().split("\n"):
-            if line.find("VERSION") != -1:
-                version = line.replace("VERSION = ", "")
-            if line.find("PATCHLEVEL") != -1:
-                rest = line.replace("PATCHLEVEL = ", "")
-        make = "suse"
-        return (make, float(version))
+    allowed_distros = ["rhel", "centos", "fedora", "debian", "ubuntu"]
+
+    if distroname in allowed_distros:
+        return distroname, float(version)
+    elif distroname is "sles" or "suse" or "opensuse" in distroname:
+        return "suse", float(version)
     else:
-        return ("unknown", 0)
+        return "unkown", 0.0
 
 
 def uniqify(lst, purge=None):

--- a/koan/utils.py
+++ b/koan/utils.py
@@ -25,7 +25,6 @@ from __future__ import print_function
 
 import os
 import random
-import re
 import tempfile
 import traceback
 
@@ -330,34 +329,46 @@ def check_dist():
     """
     Determines what distro we're running under (with the distro module).
     """
-    distroname = distro.like()
-    if distroname is "debian":
-        return distroname
-    elif distroname is "suse" or distroname is "sles" or "opensuse" in distroname:
+    # FIXME: This mimics the old logic but is certanly wrong
+
+    if distro.id() is "debian":
+        return "debian"
+
+    if distro.like() is "suse":
         return "suse"
-    else:
-        # valid for Fedora and all Red Hat / Fedora derivatives
-        return "redhat"
+
+    # valid for Fedora and all Red Hat / Fedora derivatives
+    return "redhat"
 
 
 def os_release():
     """
     This code detects your os with the distro module and return the name and version. If it is not detected correctly it
-    returns "unkown" (str) and "0" (float).
+    returns "unknown" (str) and "0" (float).
     @:returns tuple (str, float)
         WHERE
         str is the name
         int is the version number
     """
-    distroname = distro.like()
+    distroname = distro.id()
+    distrolike = distro.like()
     version = distro.version()
 
-    allowed_distros = ["rhel", "centos", "fedora", "debian", "ubuntu", "suse"]
+    redhat = ["centos", "fedora", "rhel"]
 
-    if distroname in allowed_distros:
+    if distroname in redhat or distrolike in redhat:
+        if distroname in ["centos", "fedora"]:
+            return distroname, float(version)
+        else:
+            return "redhat", float(version)
+
+    if distroname is ["debian", "ubuntu"]:
         return distroname, float(version)
-    else:
-        return "unkown", 0.0
+
+    if distrolike is "suse":
+        return "suse", float(version)
+
+    return "unknown", 0.0
 
 
 def uniqify(lst, purge=None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ simplejson
 ethtool
 pyflakes
 pycodestyle
+distro
+libvirt-python


### PR DESCRIPTION
This removes the manual detection of the distro and instead uses the distro module. Currently there is a broken behavior on SUSE this is fixed with using the distro module.