### PR TITLE
Do not add extra unneeded quote around argument to grubby --args

### DIFF
--- a/koan/app.py
+++ b/koan/app.py
@@ -1184,7 +1184,7 @@ class Koan:
                         profile_data,
                         'initrd_local'),
                     "--args",
-                    "\"%s\"" %
+                    "%s" %
                     k_args]
 
                 if not self.no_copy_default:


### PR DESCRIPTION
The arguments to the subrocess call are already individual arguments so no need to quote.  And grubby on EL8 now preserves the quotes into the kernel arguments.