### PR TITLE
Migrate requirements.txt info to setup.py using setuptools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,7 @@ addons:
       - libvirt-dev
       - gcc
 before_script:
-  - pip3 install pyflakes pycodestyle
-  - pip3 install -r requirements-test.txt
+  - pip3 install .[lint,test]
 script:
   - make qa
   - pytest

--- a/koan.spec
+++ b/koan.spec
@@ -59,11 +59,13 @@ BuildArchitectures: noarch
 
 %if %{use_python3}
 BuildRequires: python3
+BuildRequires: python3-setuptools
 Requires: python3
 Requires: python3-netifaces
 Requires: python3-simplejson
 %else
 BuildRequires: python >= 2.3
+BuildRequires: python-setuptools
 Requires: python >= 2.3
 Requires: python-ethtool
 Requires: python-simplejson

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,0 @@
--r requirements.txt
-pytest
-nose

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
-simplejson
-ethtool
-pyflakes
-pycodestyle
-distro
-libvirt-python
-netifaces

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License
 along with zenossctl. If not, see <http://www.gnu.org/licenses/>.
 """
 
-from distutils.core import setup
+from setuptools import setup
 
 VERSION = "2.9.0"
 
@@ -29,6 +29,14 @@ setup(
     packages=['koan'],
     license='GPLv2',
     scripts=['bin/koan', 'bin/cobbler-register'],
+    install_requires=[
+        'simplejson',
+        'ethtool',
+        'distro',
+        'libvirt-python',
+        'netifaces',
+    ],
+    extras_require={'lint': ['pyflakes', 'pycodestyle'], 'test': ['pytest', 'nose']},
     # data_files=[('/etc/zenossctl', ['config/zenossctl.json'])],
 )
 


### PR DESCRIPTION
This makes it easier for the dependencies to be codified with the application install, and allows for RPM's dependency generator to automatically populate the correct dependencies on distributions that have it (such as Fedora and RHEL/CentOS 8).