### PR TITLE
app: find autoinstall with default ks

### DIFF
--- a/koan/app.py
+++ b/koan/app.py
@@ -641,7 +641,7 @@ class Koan:
 
         if "autoinst" in profile_data:
             # fix URLs
-            if profile_data["autoinst"][0] == "/":
+            if profile_data["autoinst"][0] == "/" or os.path.dirname(profile_data["autoinst"]) == '':
                 if not self.system:
                     profile_data["autoinst"] = "http://%s/cblr/svc/op/ks/profile/%s" % (
                         profile_data['http_server'], profile_data['name'])


### PR DESCRIPTION
try to use default ks if autoinst is
not specified

port from https://gitee.com/src-anolis-sig/koan/blob/a8-cobbler-stream-3.3/0001-app-find-autoinstall-with-default-ks.patch