### PR TITLE
Allow setting virt-bridge to "none" to disable all network configuration

### DIFF
--- a/changelog.d/96.added
+++ b/changelog.d/96.added
@@ -1,0 +1,1 @@
+Allow setting virt-bridge to "none" or empty to disable all network configuration

--- a/koan/virtinstall.py
+++ b/koan/virtinstall.py
@@ -456,7 +456,10 @@ def build_commandline(
         cmd += "--disk path=%s,device=floppy " % floppy
 
     for bridge, mac in nics:
-        cmd += "--network bridge=%s" % bridge
+        if bridge == "none":
+            cmd += "--network none"
+        else:
+            cmd += "--network bridge=%s" % bridge
         if net_model and not disable_net_model:
             cmd += ",model=%s" % net_model
         if mac:

--- a/koan/virtinstall.py
+++ b/koan/virtinstall.py
@@ -146,9 +146,8 @@ def _sanitize_nics(nics, bridge, profile_bridge, network_count):
         if not bridge:
             intf_bridge = intf["virt_bridge"]
             if intf_bridge == "":
-                if profile_bridge == "":
-                    raise InfoException("virt-bridge setting is not defined in cobbler")
-                intf_bridge = profile_bridge
+                if profile_bridge != "":
+                    intf_bridge = profile_bridge
 
         else:
             if bridge.find(",") == -1:
@@ -157,7 +156,8 @@ def _sanitize_nics(nics, bridge, profile_bridge, network_count):
                 bridges = bridge.split(",")
                 intf_bridge = bridges[counter]
 
-        ret.append((intf_bridge, mac))
+        if intf_bridge != "":
+            ret.append((intf_bridge, mac))
 
     return ret
 
@@ -308,8 +308,9 @@ def build_commandline(
             bridge = profile_data["virt_bridge"]
 
         if bridge == "":
-            raise InfoException("virt-bridge setting is not defined in cobbler")
-        nics = [(bridge, None)]
+            nics = [("none", None)]
+        else:
+            nics = [(bridge, None)]
 
     kernel = profile_data.get("kernel_local")
     initrd = profile_data.get("initrd_local")


### PR DESCRIPTION
I'm still kind of mulling this over, but figured I would get it out there for more comments.

My use case is that I want to install VMs with SR-IOV hostdev interfaces.  Unfortunately, virt-install does not yet support this (see https://github.com/virt-manager/virt-manager/issues/500), so  the only way I've figured to do this is as follows:
```
sudo koan --server=${COBBLER_SERVER} --virt --system ${name} --graphics spice --virt-type kvm --qemu-disk-type scsi ${opts}

# Remove any bridged interface setup for the hostdev MAC and attach the hostdev interface
if [ -n "$hostdev" ]
then
   virsh detach-interface ${name} bridge --mac ${hostdev_mac} --live --config || :
   virsh nodedev-detach pci_0000_${hostdev//[:.]/_}
   virsh attach-interface ${name} hostdev 0000:${hostdev} --mac ${hostdev_mac}
fi
```
It's somewhat cleaner and I can ditch the detach-interface call if I don't have any networks configured for the VM in the first place.

I'm not sure if there are any other use-cases for configuring a VM without a network interface.

The other TODO is to get cobbler to be able to save the information needed for  hostdev interface configurations, namely the PCI ID and that it is the type `hostdev`.  But that isn't really useful until virt-install supports it.