### PR TITLE
fix: allow custom port to be added to the autoinstall URL

### DIFF
--- a/koan/app.py
+++ b/koan/app.py
@@ -484,7 +484,7 @@ class Koan:
                     url_fmt = "http://%s/cblr/svc/op/ks/profile/%s"
                 else:
                     url_fmt = "http://%s/cblr/svc/op/ks/system/%s"
-                url = url_fmt % (self.server, profile_data["name"])
+                url = url_fmt % (profile_data["http_server"], profile_data["name"])
             else:
                 url = profile_data["autoinst"]
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,26 @@
+from koan.app import Koan
+
+
+def test_get_install_tree_from_autoinst_uses_http_server_port(mocker):
+    # Arrange
+    # Cobbler bakes a non-default http_port into "http_server" (e.g. "host:10080"),
+    # while "server" is just the plain hostname/IP koan was invoked with.
+    k = Koan()
+    k.server = "192.168.10.112"
+    k.system = None
+    profile_data = {
+        "name": "centos7.4-x86_64",
+        "autoinst": "http://192.168.10.112:10080/cblr/svc/op/ks/profile/centos7.4-x86_64",
+        "http_server": "192.168.10.112:10080",
+    }
+    mock_urlread = mocker.patch("koan.utils.urlread", return_value=b"")
+
+    # Act
+    k.get_install_tree_from_autoinst(profile_data)
+
+    # Assert
+    requested_url = mock_urlread.call_args[0][0]
+    assert (
+        requested_url
+        == "http://192.168.10.112:10080/cblr/svc/op/ks/profile/centos7.4-x86_64"
+    )


### PR DESCRIPTION
## Linked Items

Fixes #28
Fixes #63

## Description

This PR allows the Cobbler URL to support a custom port while fetching content from the server.

## Behaviour changes

None

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [x] Unit-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] No tests required 
