### PR TITLE
fix: interpret vm shutdown as running

### DIFF
--- a/koan/utils.py
+++ b/koan/utils.py
@@ -28,7 +28,7 @@ VIRT_STATE_NAME_MAP = {
     1: "running",
     2: "running",
     3: "paused",
-    4: "shutdown",
+    4: "running",
     5: "shutdown",
     6: "crashed",
 }


### PR DESCRIPTION
## Linked Items

Fixes #26

## Description

This PR changes the interpretation of a VM being shut down, from "shutdown" to "running".

## Behaviour changes

Old: VM is being recreated during shutdown

New: VM is recreated after being fully shut down

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] Code is already covered by Unit-Tests
- [x] No tests required 
